### PR TITLE
Fixing Search Bug

### DIFF
--- a/BleachHack-Fabric-1.16/src/main/java/bleach/hack/module/mods/Search.java
+++ b/BleachHack-Fabric-1.16/src/main/java/bleach/hack/module/mods/Search.java
@@ -62,6 +62,8 @@ public class Search extends Module {
 	private Queue<Pair<BlockPos, BlockState>> queuedBlocks = new ArrayDeque<>();
 
 	private Set<Block> prevBlockList = new HashSet<>();
+	
+	private int oldViewDistance = -1;
 
 	public Search() {
 		super("Search", KEY_UNBOUND, Category.RENDER, "Highlights specified Blocks",
@@ -90,7 +92,7 @@ public class Search extends Module {
 	public void onTick(EventTick event) {
 		Set<Block> blockList = getSetting(4).asList(Block.class).getItems();
 
-		if (!prevBlockList.equals(blockList)) {
+		if (!prevBlockList.equals(blockList) || (oldViewDistance != mc.options.viewDistance && oldViewDistance != -1)) {
 			reset();
 
 			for (Chunk chunk: WorldUtils.getLoadedChunks()) {
@@ -98,6 +100,7 @@ public class Search extends Module {
 			}
 
 			prevBlockList = new HashSet<>(blockList);
+			oldViewDistance = mc.options.viewDistance;
 			return;
 		}
 

--- a/BleachHack-Fabric-1.16/src/main/java/bleach/hack/module/mods/Search.java
+++ b/BleachHack-Fabric-1.16/src/main/java/bleach/hack/module/mods/Search.java
@@ -92,7 +92,7 @@ public class Search extends Module {
 	public void onTick(EventTick event) {
 		Set<Block> blockList = getSetting(4).asList(Block.class).getItems();
 
-		if (!prevBlockList.equals(blockList) || (oldViewDistance != mc.options.viewDistance && oldViewDistance != -1)) {
+		if (!prevBlockList.equals(blockList) || oldViewDistance != mc.options.viewDistance) {
 			reset();
 
 			for (Chunk chunk: WorldUtils.getLoadedChunks()) {

--- a/BleachHack-Fabric-1.17/src/main/java/bleach/hack/module/mods/Search.java
+++ b/BleachHack-Fabric-1.17/src/main/java/bleach/hack/module/mods/Search.java
@@ -92,7 +92,7 @@ public class Search extends Module {
 	public void onTick(EventTick event) {
 		Set<Block> blockList = getSetting(4).asList(Block.class).getItems();
 
-		if (!prevBlockList.equals(blockList) || (oldViewDistance != mc.options.viewDistance && oldViewDistance != -1)) {
+		if (!prevBlockList.equals(blockList) || oldViewDistance != mc.options.viewDistance) {
 			reset();
 
 			for (Chunk chunk: WorldUtils.getLoadedChunks()) {

--- a/BleachHack-Fabric-1.17/src/main/java/bleach/hack/module/mods/Search.java
+++ b/BleachHack-Fabric-1.17/src/main/java/bleach/hack/module/mods/Search.java
@@ -62,6 +62,8 @@ public class Search extends Module {
 	private Queue<Pair<BlockPos, BlockState>> queuedBlocks = new ArrayDeque<>();
 
 	private Set<Block> prevBlockList = new HashSet<>();
+	
+	private int oldViewDistance = -1;
 
 	public Search() {
 		super("Search", KEY_UNBOUND, Category.RENDER, "Highlights specified Blocks",
@@ -90,7 +92,7 @@ public class Search extends Module {
 	public void onTick(EventTick event) {
 		Set<Block> blockList = getSetting(4).asList(Block.class).getItems();
 
-		if (!prevBlockList.equals(blockList)) {
+		if (!prevBlockList.equals(blockList) || (oldViewDistance != mc.options.viewDistance && oldViewDistance != -1)) {
 			reset();
 
 			for (Chunk chunk: WorldUtils.getLoadedChunks()) {
@@ -98,8 +100,10 @@ public class Search extends Module {
 			}
 
 			prevBlockList = new HashSet<>(blockList);
+			oldViewDistance = mc.options.viewDistance;
 			return;
 		}
+		
 
 		while (!queuedBlocks.isEmpty()) {
 			Pair<BlockPos, BlockState> blockPair = queuedBlocks.poll();


### PR DESCRIPTION
I have no idea how I found this bug this early but when lowering the view distance while having search enabled will cause some blocks to never get deleted. This is fixed.

**Also a suggestion: Maybe make a setting in which you can change the distance blocks get searched or at least a slider to regulate the maximum amount of shown blocks. (In the current state searching in the Nether for these gold blocks is just impossible)**