### PR TITLE
"Idea" for an interaction screen

### DIFF
--- a/BleachHack-Fabric-1.17/src/main/java/bleach/hack/BleachHack.java
+++ b/BleachHack-Fabric-1.17/src/main/java/bleach/hack/BleachHack.java
@@ -28,6 +28,9 @@ import bleach.hack.util.FriendManager;
 import bleach.hack.util.file.BleachFileHelper;
 import bleach.hack.util.file.BleachFileMang;
 import net.fabricmc.api.ModInitializer;
+
+import java.util.HashMap;
+
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -42,6 +45,7 @@ public class BleachHack implements ModInitializer {
 	public static final EventBus eventBus = new EventBus();
 
 	public static FriendManager friendMang;
+	public static HashMap<String, String> interaction = new HashMap<String, String>();
 
 	private Logger logger;
 	//private BleachFileMang bleachFileManager;
@@ -77,7 +81,8 @@ public class BleachHack implements ModInitializer {
 		ClickGui.clickGui.initWindows();
 		BleachFileHelper.readClickGui();
 		BleachFileHelper.readFriends();
-
+		BleachFileHelper.readInteraction();
+		
 		CommandManager.readPrefix();
 
 		JsonElement mainMenu = BleachFileHelper.readMiscSetting("customTitleScreen");

--- a/BleachHack-Fabric-1.17/src/main/java/bleach/hack/command/CommandManager.java
+++ b/BleachHack-Fabric-1.17/src/main/java/bleach/hack/command/CommandManager.java
@@ -45,6 +45,7 @@ public class CommandManager {
 			new CmdGive(),
 			new CmdGuiReset(),
 			new CmdHelp(),
+			new CmdInteraction(),
 			new CmdInvPeek(),
 			new CmdNBT(),
 			new CmdNotebot(),

--- a/BleachHack-Fabric-1.17/src/main/java/bleach/hack/command/commands/CmdInteraction.java
+++ b/BleachHack-Fabric-1.17/src/main/java/bleach/hack/command/commands/CmdInteraction.java
@@ -1,0 +1,126 @@
+package bleach.hack.command.commands;
+
+import java.util.HashMap;
+
+import bleach.hack.BleachHack;
+import bleach.hack.command.Command;
+import bleach.hack.util.BleachLogger;
+import bleach.hack.util.file.BleachFileHelper;
+
+public class CmdInteraction extends Command{
+	HashMap<String, String> interaction = BleachHack.interaction;
+	
+	@Override
+	public String getAlias() {
+		return "interaction";
+	}
+
+	@Override
+	public String getDescription() {
+		return "Manage the things which appear on the interaction screen. Use %name";
+	}
+
+	@Override
+	public String getSyntax() {
+		return "interaction add ( <alias> ) ( <command> ) | interaction remove ( <alias / command> ) | interection list | interaction clear";
+	}
+
+	@Override
+	public void onCommand(String command, String[] args) throws Exception {
+		
+		if (args[0].equalsIgnoreCase("add")) 
+			add(args);
+		else if (args[0].equalsIgnoreCase("remove"))
+			remove(args);
+		else if (args[0].equalsIgnoreCase("clear"))
+			clear();
+		else if (args[0].equalsIgnoreCase("list"))
+			list();
+		else 
+			printSyntaxError();
+		BleachFileHelper.SCHEDULE_SAVE_INTERACTION = true;
+	}
+	
+	private void add (String[] args) {
+		if (args.length < 3) {
+			printSyntaxError("No alias or command specified");
+			return;
+		} 
+		
+		if (!args[1].equals("(")) {
+			printSyntaxError("Don´t forget the parentheses!");
+			return;
+		}
+		
+		String alias = "", command = "";
+		int interactiontart = -1;
+		for (int i = 2; i < args.length; i++) {
+			if (!args[i].equals(")"))
+				alias += args[i] + " ";
+			else {
+				interactiontart = i + 1;
+				break;
+			}
+		}
+		
+		if(!args[interactiontart].equals("(")){
+			printSyntaxError("Don´t forget the parentheses!");
+			return;
+		}
+		
+		for (int i = interactiontart + 1; i < args.length; i++) 
+			if (!args[i].equals(")"))
+				command += args[i] + " ";
+		
+		if (alias.contains(":") || command.contains(":")) {
+			printSyntaxError("Don´t use the \":\" symbol");
+		}
+		
+		if (interaction.size() <= 15) {
+			interaction.put(alias.trim(), command.trim());
+			BleachLogger.infoMessage("Added: " + alias.trim() + " : " + command.trim());
+		}
+		else
+			BleachLogger.errorMessage("You can´t have more then 15 entrys. Remove one entry or clear all");
+	}
+	
+	private void remove (String[] args) {
+		if (interaction.size() == 0) {
+			BleachLogger.errorMessage("Nothing to remove. You first have to add an entry");
+			return;
+		}
+		
+		if(!args[1].equals("(")) {
+			printSyntaxError("Don´t forget the parentheses!");
+			return;
+		}
+		
+		String result = "";
+		
+		for (int i = 2; i < args.length; i++) 
+			if (!args[i].equals(")"))
+				result += args[i] + " ";
+		
+		HashMap<String, String> map = BleachHack.interaction;
+		for (String s: map.keySet())
+			if (s.equals(result) || map.get(s).equals(result)) {
+				map.remove(s);
+				BleachLogger.infoMessage("Removed: " + s);
+			}
+	}
+	
+	private void clear () {
+		interaction.clear();
+		BleachLogger.infoMessage("Successfully cleared the list");
+	}
+	
+	private void list () {
+		if (interaction.size() == 0) {
+			BleachLogger.errorMessage("Nothing to see here. You first have to add an entry");
+			return;
+		}
+		
+		for (String s: interaction.keySet())
+			BleachLogger.infoMessage(s + " : " + interaction.get(s));
+	}
+}

--- a/BleachHack-Fabric-1.17/src/main/java/bleach/hack/command/commands/CmdInteraction.java
+++ b/BleachHack-Fabric-1.17/src/main/java/bleach/hack/command/commands/CmdInteraction.java
@@ -7,6 +7,9 @@ import bleach.hack.command.Command;
 import bleach.hack.util.BleachLogger;
 import bleach.hack.util.file.BleachFileHelper;
 
+/**
+ * @author <a href="https://github.com/lasnikprogram">Lasnik</a>
+ */
 public class CmdInteraction extends Command{
 	HashMap<String, String> interaction = BleachHack.interaction;
 	
@@ -17,12 +20,12 @@ public class CmdInteraction extends Command{
 
 	@Override
 	public String getDescription() {
-		return "Manage the things which appear on the interaction screen. Use %name";
+		return "Manage the things which appear on the interaction screen. Use %name and %suggestion";
 	}
 
 	@Override
 	public String getSyntax() {
-		return "interaction add ( <alias> ) ( <command> ) | interaction remove ( <alias / command> ) | interection list | interaction clear";
+		return "interaction add ( <alias> ) ( <command> ) | interaction remove ( <alias/command> ) | interection list | interaction clear";
 	}
 
 	@Override
@@ -38,12 +41,13 @@ public class CmdInteraction extends Command{
 			list();
 		else 
 			printSyntaxError();
+		
 		BleachFileHelper.SCHEDULE_SAVE_INTERACTION = true;
 	}
 	
 	private void add (String[] args) {
-		if (args.length < 3) {
-			printSyntaxError("No alias or command specified");
+		if (args.length < 7) {
+			printSyntaxError();
 			return;
 		} 
 		
@@ -85,6 +89,11 @@ public class CmdInteraction extends Command{
 	}
 	
 	private void remove (String[] args) {
+		if (args.length < 4) {
+			printSyntaxError();
+			return;
+		}
+		
 		if (interaction.size() == 0) {
 			BleachLogger.errorMessage("Nothing to remove. You first have to add an entry");
 			return;
@@ -96,14 +105,14 @@ public class CmdInteraction extends Command{
 		}
 		
 		String result = "";
-		
 		for (int i = 2; i < args.length; i++) 
 			if (!args[i].equals(")"))
 				result += args[i] + " ";
 		
+		System.out.println(result);
 		HashMap<String, String> map = BleachHack.interaction;
 		for (String s: map.keySet())
-			if (s.equals(result) || map.get(s).equals(result)) {
+			if (s.equalsIgnoreCase(result) || map.get(s).equalsIgnoreCase(result)) {
 				map.remove(s);
 				BleachLogger.infoMessage("Removed: " + s);
 			}

--- a/BleachHack-Fabric-1.17/src/main/java/bleach/hack/gui/InteractionScreen.java
+++ b/BleachHack-Fabric-1.17/src/main/java/bleach/hack/gui/InteractionScreen.java
@@ -1,0 +1,212 @@
+package bleach.hack.gui;
+
+import java.awt.Point;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import org.lwjgl.glfw.GLFW;
+
+import com.mojang.blaze3d.platform.GlStateManager;
+import com.mojang.blaze3d.systems.RenderSystem;
+
+import bleach.hack.BleachHack;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.ChatScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.option.KeyBinding;
+import net.minecraft.client.render.GameRenderer;
+import net.minecraft.client.util.InputUtil;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.text.LiteralText;
+import net.minecraft.util.math.MathHelper;
+
+public class InteractionScreen extends Screen {
+
+	private String name, current;
+	private int crosshairX, crosshairY, at = -1;
+	private float yaw, pitch;
+
+	public InteractionScreen(String name) {
+		super(new LiteralText("Menu Screen"));
+		this.name = name;
+		System.out.println(name);
+	}
+
+	public void init() {
+		super.init();
+		this.cursorMode(GLFW.GLFW_CURSOR_HIDDEN);
+		yaw = client.player.yaw;
+		pitch = client.player.pitch;
+	}
+
+	private void cursorMode(int mode) {
+		KeyBinding.unpressAll();
+		double x = (double) (this.client.getWindow().getWidth() / 2);
+		double y = (double) (this.client.getWindow().getHeight() / 2);
+		InputUtil.setCursorParameters(this.client.getWindow().getHandle(), GLFW.GLFW_CURSOR_HIDDEN, x, y);
+	}
+
+	public void tick() {
+		if (GLFW.glfwGetMouseButton(MinecraftClient.getInstance().getWindow().getHandle(),
+				GLFW.GLFW_MOUSE_BUTTON_MIDDLE) == GLFW.GLFW_RELEASE)
+			onClose();
+	}
+
+	public void onClose() {
+		cursorMode(GLFW.GLFW_CURSOR_NORMAL);
+		if (current != null) {
+			String message = BleachHack.interaction.get(current).replaceAll("%name", name);
+			if (message.startsWith("%suggestion")) 
+				client.openScreen(new ChatScreen(message.replaceFirst("%suggestion", "")));
+			else {
+				client.player.sendChatMessage(message);
+				client.openScreen((Screen) null);
+			}
+		} else
+			client.openScreen((Screen) null);
+	}
+
+	public boolean isPauseScreen() {
+		return false;
+	}
+
+	public void render(MatrixStack matrix, int mouseX, int mouseY, float delta) {
+		RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+		RenderSystem.setShader(GameRenderer::getPositionTexShader);
+		RenderSystem.setShaderTexture(0, GUI_ICONS_TEXTURE);
+		RenderSystem.enableBlend();
+		RenderSystem.blendFuncSeparate(GlStateManager.SrcFactor.ONE_MINUS_DST_COLOR,
+				GlStateManager.DstFactor.ONE_MINUS_SRC_COLOR, GlStateManager.SrcFactor.ONE,
+				GlStateManager.DstFactor.ZERO);
+		drawTexture(matrix, crosshairX - 8, crosshairY - 8, 0, 0, 15, 15);
+		
+		drawDots(matrix, (int) (Math.min(height, width) / 2 * 0.75), mouseX, mouseY);
+		
+		int scale = client.options.guiScale;
+		Vector2 mouse = new Vector2(mouseX, mouseY);
+		Vector2 center = new Vector2(width / 2, height / 2);
+		mouse.subtract(center);
+		mouse.normalize();
+		Vector2 cross = mouse;
+		
+		if (scale == 0)
+			scale = 4;
+		
+		if (Math.hypot(width / 2 - mouseX, height / 2 - mouseY) < 1f / scale * 200f)
+			mouse.multiply((float) Math.hypot(width / 2 - mouseX, height / 2 - mouseY));
+		else 
+			mouse.multiply(1f / scale * 200f);
+		
+		
+		this.crosshairX = (int) mouse.x + width / 2;
+		this.crosshairY = (int) mouse.y + height / 2;
+		
+		client.player.yaw = yaw + cross.x / 3;
+		client.player.pitch = MathHelper.clamp(pitch + cross.y / 3, -90f, 90f);
+		super.render(matrix, mouseX, mouseY, delta);
+	}
+
+
+	private void drawRect(MatrixStack matrix, int startX, int startY, int width, int height, int colorInner,int colorOuter) {
+		drawHorizontalLine(matrix, startX, startX + width, startY, colorOuter);
+		drawHorizontalLine(matrix, startX, startX + width, startY + height, colorOuter);
+		drawVerticalLine(matrix, startX, startY, startY + height, colorOuter);
+		drawVerticalLine(matrix, startX + width, startY, startY + height, colorOuter);
+		fill(matrix, startX + 1, startY + 1, startX + width, startY + height, colorInner);
+	}
+
+	private void drawDots(MatrixStack matrix, int radius, int mouseX, int mouseY) {
+		HashMap<String, String> map = BleachHack.interaction;
+		ArrayList<Point> pointList = new ArrayList<Point>();
+		String cache[] = new String[map.size()];
+		double lowestDistance = Double.MAX_VALUE;
+		int i = -1;
+		for (String string: map.keySet()) {
+			i++;
+			double s = (double) i / map.size() * 2 * Math.PI;
+			int x = (int) Math.round(radius * Math.cos(s) + width / 2);
+			int y = (int) Math.round(radius * Math.sin(s) + height / 2);
+			drawTextField(matrix, x, y, string);
+			cache[i] = string;
+			pointList.add(new Point(x, y));
+			
+			if (Math.hypot(x - mouseX, y - mouseY) < lowestDistance) {
+				lowestDistance = Math.hypot(x - mouseX, y - mouseY);
+				at = i;
+			}
+		}
+		for (int j = 0; j < map.size(); j++) {
+			Point current = pointList.get(j);
+			if (pointList.get(at) == current) {
+				drawDot(matrix, current.x - 4, current.y - 4, 0xFF4CFF00);
+				this.current = cache[at];
+			}
+			else
+				drawDot(matrix, current.x - 4, current.y - 4, 0xFF0094FF);
+		}
+	}
+	
+
+	private void drawTextField(MatrixStack matrix, int x, int y, String key) {
+		if (x >= width / 2) {
+			drawRect(matrix, x + 10, y - 8, textRenderer.getWidth(key) + 3, 15, 0x80808080, 0xFF000000);
+			drawStringWithShadow(matrix, textRenderer, key, x + 12, y - 4, 0xFFFFFFFF);
+		} else {
+			drawRect(matrix, x - 14 - textRenderer.getWidth(key), y - 8, textRenderer.getWidth(key) + 3, 15, 0x80808080, 0xFF000000);
+			drawStringWithShadow(matrix, textRenderer, key, x - 12 - textRenderer.getWidth(key), y - 4, 0xFFFFFFFF);
+		}
+	}
+	
+	// Literally drawing it in code
+	private void drawDot(MatrixStack matrix, int startX, int startY, int colorInner) {
+		// Draw dot itself
+		drawHorizontalLine(matrix, startX + 2, startX + 5, startY, 0xFF000000);
+		drawHorizontalLine(matrix, startX + 1, startX + 6, startY + 1, 0xFF000000);
+		drawHorizontalLine(matrix, startX + 2, startX + 5, startY + 1, colorInner);
+		fill(matrix, startX, startY + 2, startX + 8, startY + 6, 0xFF000000);
+		fill(matrix, startX + 1, startY + 2, startX + 7, startY + 6, colorInner);
+		drawHorizontalLine(matrix, startX + 1, startX + 6, startY + 6, 0xFF000000);
+		drawHorizontalLine(matrix, startX + 2, startX + 5, startY + 6, colorInner);
+		drawHorizontalLine(matrix, startX + 2, startX + 5, startY + 7, 0xFF000000);
+		
+		// Draw light overlay
+		drawHorizontalLine(matrix, startX + 2, startX + 3, startY + 1, 0x80FFFFFF);
+		drawHorizontalLine(matrix, startX + 1, startX + 1, startY + 2, 0x80FFFFFF);
+	}
+}
+
+
+// Bruh literally making my own Vector class because I am smart
+class Vector2 {
+    float x, y;
+
+    Vector2 (float x, float y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    void normalize() {
+        float mag = getMag();
+        if (mag != 0 && mag != 1)
+            divide(mag);
+    }
+
+    void subtract (Vector2 vec) {
+        this.x -= vec.x;
+        this.y -= vec.y;
+    }
+
+    void divide(float n) {
+        x /= n;
+        y /= n;
+    }
+
+    void multiply(float n) {
+        x *= n;
+        y *= n;
+    }
+
+    private float getMag() {
+        return (float) Math.sqrt(x * x + y * y);
+    }
+}

--- a/BleachHack-Fabric-1.17/src/main/java/bleach/hack/gui/InteractionScreen.java
+++ b/BleachHack-Fabric-1.17/src/main/java/bleach/hack/gui/InteractionScreen.java
@@ -88,7 +88,7 @@ public class InteractionScreen extends Screen {
 		matrix.scale (2f, 2f, 1f);
 		drawCenteredString(matrix, textRenderer, "Interaction Screen", width / 4, 6, 0xFFFFFFFF);
 		matrix.scale(1f / 2f, 1f / 2f, 1f);
-		drawCenteredString(matrix, textRenderer, "Created by Lasnik#0294", width / 2, 50, 0xFFFFFFFF);
+		drawCenteredString(matrix, textRenderer, "Created by Lasnik#0294", width / 2, 30, 0xFFFFFFFF);
 		
 		int scale = client.options.guiScale;
 		Vector2 mouse = new Vector2(mouseX, mouseY);

--- a/BleachHack-Fabric-1.17/src/main/java/bleach/hack/mixin/MixinClientWorld.java
+++ b/BleachHack-Fabric-1.17/src/main/java/bleach/hack/mixin/MixinClientWorld.java
@@ -34,11 +34,12 @@ public class MixinClientWorld {
 					BleachFileHelper.saveClickGui();
 				if (BleachFileHelper.SCHEDULE_SAVE_FRIENDS)
 					BleachFileHelper.saveFriends();
+				if (BleachFileHelper.SCHEDULE_SAVE_INTERACTION)
+					BleachFileHelper.saveInteraction();
 			}
 
 			BleachQueue.nextQueue();
-		} catch (Exception e) {
-		}
+		} catch (Exception e) {}
 
 		EventTick event = new EventTick();
 		BleachHack.eventBus.post(event);

--- a/BleachHack-Fabric-1.17/src/main/java/bleach/hack/mixin/MixinIngameHud.java
+++ b/BleachHack-Fabric-1.17/src/main/java/bleach/hack/mixin/MixinIngameHud.java
@@ -27,15 +27,16 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import bleach.hack.BleachHack;
 import bleach.hack.event.events.EventDrawOverlay;
 import bleach.hack.event.events.EventRenderOverlay;
+import bleach.hack.gui.InteractionScreen;
+import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.hud.InGameHud;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.Identifier;
 
 @Mixin(InGameHud.class)
 public class MixinIngameHud {
-
 	@Unique private boolean bypassRenderOverlay = false;
-
+	
 	@Shadow private void renderOverlay(Identifier texture, float opacity) {}
 
 	@Inject(method = "render", at = @At("RETURN"), cancellable = true)
@@ -62,6 +63,15 @@ public class MixinIngameHud {
 			bypassRenderOverlay = true;
 			renderOverlay(event.getTexture(), event.getOpacity());
 			bypassRenderOverlay = false;
+		}
+	}
+	
+	
+	@Inject(method = "renderCrosshair", at = @At("HEAD"), cancellable = true)
+	private void renderCrosshair(MatrixStack matrices, CallbackInfo ci) {
+		MinecraftClient client = MinecraftClient.getInstance();
+		if (client.currentScreen instanceof InteractionScreen) {
+			ci.cancel();
 		}
 	}
 }

--- a/BleachHack-Fabric-1.17/src/main/java/bleach/hack/module/mods/Interaction.java
+++ b/BleachHack-Fabric-1.17/src/main/java/bleach/hack/module/mods/Interaction.java
@@ -1,0 +1,42 @@
+package bleach.hack.module.mods;
+
+import java.util.Optional;
+
+import org.lwjgl.glfw.GLFW;
+
+import com.google.common.eventbus.Subscribe;
+
+import bleach.hack.event.events.EventTick;
+import bleach.hack.gui.interaction.InteractionScreen;
+import bleach.hack.module.Category;
+import bleach.hack.module.Module;
+import net.minecraft.client.render.debug.DebugRenderer;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+
+public class Interaction extends Module {
+
+	private boolean released;
+	
+	public Interaction() {
+		super("MouseMenu", KEY_UNBOUND, Category.MISC, "An interaction screen pressing the middle mouse button while looking to an entity. Customizable via the $interaction command");
+	}
+	
+	@Subscribe
+	public void onTick(EventTick event) {
+		if (GLFW.glfwGetMouseButton(mc.getWindow().getHandle(), GLFW.GLFW_MOUSE_BUTTON_MIDDLE) == GLFW.GLFW_PRESS && released) {
+			released = false;
+			
+			Optional<Entity> lookingAt = DebugRenderer.getTargetedEntity(mc.player, 20);
+			
+			if (lookingAt.isPresent()) {
+				Entity e = lookingAt.get();
+
+				if (e instanceof LivingEntity) {
+					mc.openScreen(new InteractionScreen(e.getName().getString()));
+				}
+			}
+		} else if (GLFW.glfwGetMouseButton(mc.getWindow().getHandle(), GLFW.GLFW_MOUSE_BUTTON_MIDDLE) == GLFW.GLFW_RELEASE)
+			released = true;
+	}
+}

--- a/BleachHack-Fabric-1.17/src/main/java/bleach/hack/module/mods/Interaction.java
+++ b/BleachHack-Fabric-1.17/src/main/java/bleach/hack/module/mods/Interaction.java
@@ -19,7 +19,7 @@ public class Interaction extends Module {
 	private boolean released;
 	
 	public Interaction() {
-		super("MouseMenu", KEY_UNBOUND, Category.MISC, "An interaction screen pressing the middle mouse button while looking to an entity. Customizable via the $interaction command");
+		super("Interaction screen", KEY_UNBOUND, Category.MISC, "An interaction screen pressing the middle mouse button while looking to an entity. Customizable via the $interaction command");
 	}
 	
 	@Subscribe

--- a/BleachHack-Fabric-1.17/src/main/java/bleach/hack/module/mods/Interaction.java
+++ b/BleachHack-Fabric-1.17/src/main/java/bleach/hack/module/mods/Interaction.java
@@ -19,7 +19,7 @@ public class Interaction extends Module {
 	private boolean released;
 	
 	public Interaction() {
-		super("Interaction screen", KEY_UNBOUND, Category.MISC, "An interaction screen pressing the middle mouse button while looking to an entity. Customizable via the $interaction command");
+		super("Interaction screen", KEY_UNBOUND, Category.MISC, "An interaction screen when pressing the middle mouse button while looking to an entity. Customizable via the \"$interaction\" command");
 	}
 	
 	@Subscribe

--- a/BleachHack-Fabric-1.17/src/main/java/bleach/hack/module/mods/Interaction.java
+++ b/BleachHack-Fabric-1.17/src/main/java/bleach/hack/module/mods/Interaction.java
@@ -7,7 +7,7 @@ import org.lwjgl.glfw.GLFW;
 import com.google.common.eventbus.Subscribe;
 
 import bleach.hack.event.events.EventTick;
-import bleach.hack.gui.interaction.InteractionScreen;
+import bleach.hack.gui.InteractionScreen;
 import bleach.hack.module.Category;
 import bleach.hack.module.Module;
 import net.minecraft.client.render.debug.DebugRenderer;

--- a/BleachHack-Fabric-1.17/src/main/java/bleach/hack/module/mods/Interaction.java
+++ b/BleachHack-Fabric-1.17/src/main/java/bleach/hack/module/mods/Interaction.java
@@ -14,12 +14,15 @@ import net.minecraft.client.render.debug.DebugRenderer;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 
+/**
+ * @author <a href="https://github.com/lasnikprogram">Lasnik</a>
+ */
 public class Interaction extends Module {
 
 	private boolean released;
 	
 	public Interaction() {
-		super("Interaction screen", KEY_UNBOUND, Category.MISC, "An interaction screen when pressing the middle mouse button while looking to an entity. Customizable via the \"$interaction\" command");
+		super("InteractionScreen", KEY_UNBOUND, Category.MISC, "An interaction screen when pressing the middle mouse button while looking to an entity. Customizable via the $interaction command");
 	}
 	
 	@Subscribe

--- a/BleachHack-Fabric-1.17/src/main/java/bleach/hack/util/file/BleachFileHelper.java
+++ b/BleachHack-Fabric-1.17/src/main/java/bleach/hack/util/file/BleachFileHelper.java
@@ -210,7 +210,7 @@ public class BleachFileHelper {
 		
 		String toWrite = "";
 		for (String s: BleachHack.interaction.keySet())
-			toWrite += s + ":" + BleachHack.interaction.get(s);
+			toWrite += s + ":" + BleachHack.interaction.get(s) + "\n";
 			
 		BleachFileMang.createEmptyFile("interaction.txt");
 		BleachFileMang.appendFile(toWrite, "interaction.txt");

--- a/BleachHack-Fabric-1.17/src/main/java/bleach/hack/util/file/BleachFileHelper.java
+++ b/BleachHack-Fabric-1.17/src/main/java/bleach/hack/util/file/BleachFileHelper.java
@@ -39,6 +39,7 @@ public class BleachFileHelper {
 	public static boolean SCHEDULE_SAVE_MODULES = false;
 	public static boolean SCHEDULE_SAVE_FRIENDS = false;
 	public static boolean SCHEDULE_SAVE_CLICKGUI = false;
+	public static boolean SCHEDULE_SAVE_INTERACTION = false;
 
 	public static void saveModules() {
 		SCHEDULE_SAVE_MODULES = false;
@@ -197,5 +198,22 @@ public class BleachFileHelper {
 	public static void saveMiscSetting(String key, JsonElement value) {
 		BleachJsonHelper.addJsonElement(key, value, "misc.json");
 	}
-
+	
+	public static void readInteraction() {
+		for (String s: BleachFileMang.readFileLines("interaction.txt")) {
+			BleachHack.interaction.put(s.split(":")[0], s.split(":")[1]);
+		}
+	}
+	
+	public static void saveInteraction() {
+		SCHEDULE_SAVE_INTERACTION = false;
+		
+		String toWrite = "";
+		for (String s: BleachHack.interaction.keySet())
+			toWrite += s + ":" + BleachHack.interaction.get(s);
+			
+		BleachFileMang.createEmptyFile("interaction.txt");
+		BleachFileMang.appendFile(toWrite, "interaction.txt");
+			
+	}
 }

--- a/BleachHack-Fabric-1.17/src/main/resources/bleachhack.modules.json
+++ b/BleachHack-Fabric-1.17/src/main/resources/bleachhack.modules.json
@@ -41,6 +41,7 @@
     "Ghosthand",
     "HandProgress",
     "HoleESP",
+    "Interaction",
     "Jesus",
     "Killaura",
     "MountBypass",


### PR DESCRIPTION
I added a Module which opens a screen when the middle mouse button is clicked. 
You can customize the screen via the command `interaction` where you can add or remove an entry, list or clear all.
An entry is constructed out of an alias ( which gets shown on the interaction screen ) and a command ( which runs once the alias on the screen is selected )
The command can be customized with following two options: `%name` and `%suggestion%`. `%name` will become the name of the entity which is focused when the screen is opened. 
`%suggestion%` has to be at the start of the specified command. When it is present the command won´t be send to the chat immediately rather it will open the chat hud and just puts in the text of the command. This allows for commands like `%suggestion /msg %user ` -> When the command is executed the chat hud will appear and you can type the rest of the command. Now you don´t have to type the hole name yourself if you are standing in front of a person you want to talk to.

Here a short example video (in the old GUI): https://streamable.com/y19dz7

This is in completely alpha state and propably generates merge conflicts 👍 
Things to improve:
- [x] fix merge conflicts
- [ ] better way to add and remove alias and command (maybe it´s own screen)
- [ ] cleaner code (HashMap bad)
- [ ] port to 1.16
- [ ] more options like `%name%`