### PR TITLE
Added a PlaceInAir Hack

### DIFF
--- a/BleachHack-Fabric-1.16/src/main/java/bleach/hack/mixin/IMixinMinecraftClient.java
+++ b/BleachHack-Fabric-1.16/src/main/java/bleach/hack/mixin/IMixinMinecraftClient.java
@@ -1,0 +1,12 @@
+package bleach.hack.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.client.MinecraftClient;
+
+@Mixin(MinecraftClient.class)
+public interface IMixinMinecraftClient {
+	@Accessor
+	public abstract int getItemUseCooldown();
+}

--- a/BleachHack-Fabric-1.16/src/main/java/bleach/hack/module/mods/PlaceInAir.java
+++ b/BleachHack-Fabric-1.16/src/main/java/bleach/hack/module/mods/PlaceInAir.java
@@ -5,6 +5,7 @@ import com.google.common.eventbus.Subscribe;
 import bleach.hack.event.events.EventSendPacket;
 import bleach.hack.event.events.EventTick;
 import bleach.hack.event.events.EventWorldRender;
+import bleach.hack.mixin.IMixinMinecraftClient;
 import bleach.hack.module.Category;
 import bleach.hack.module.Module;
 import bleach.hack.setting.base.SettingColor;
@@ -12,60 +13,99 @@ import bleach.hack.setting.base.SettingMode;
 import bleach.hack.setting.base.SettingSlider;
 import bleach.hack.setting.base.SettingToggle;
 import bleach.hack.util.RenderUtils;
+import net.minecraft.block.BlockState;
 import net.minecraft.network.packet.c2s.play.PlayerInteractBlockC2SPacket;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.util.shape.VoxelShapes;
+
+/**
+ * @author <a href="https://github.com/lasnikprogram">Lasnik</a>
+ */
 
 public class PlaceInAir extends Module {
 	private boolean pressed;
-	public static boolean shouldSendPacket;
 	
 	public PlaceInAir () {
-		super("PlaceInAir", KEY_UNBOUND, Category.WORLD, "Allows you to place blocks and entities in thin air",
-				new SettingToggle("Rendered", true).withDesc("Renders an overlay where it will place the block / entity").withChildren(
+		super("PlaceInAir", KEY_UNBOUND, Category.WORLD, "Allows you to place blocks in thin air",
+				new SettingToggle("Rendered", true).withDesc("Renders an overlay where it will place the block").withChildren(
 					new SettingMode("Render", "Box+Fill", "Box", "Fill").withDesc("The rendering method"),
 					new SettingSlider("Box", 0.1, 4, 2, 1).withDesc("The thickness of the box lines"),
 					new SettingSlider("Fill", 0, 1, 0.3, 2).withDesc("The opacity of the fill"),
-					new SettingColor("Color", 1f, 1f, 0f, false)));
+					new SettingColor("Color", 240f, 211f, 165f, false)),
+				new SettingMode("Mode", "Multi", "Single").withDesc("Whether to place a block once per click or multiple blocks if the button is held down"));
 	}
 	
 	@Subscribe
 	public void onTick (EventTick event) {
-		if (mc.options.keyUse.isPressed() && !pressed && mc.crosshairTarget instanceof BlockHitResult) {
-			shouldSendPacket = false;
-            PlayerInteractBlockC2SPacket packet = new PlayerInteractBlockC2SPacket(Hand.MAIN_HAND, (BlockHitResult) mc.crosshairTarget);
-            mc.getNetworkHandler().sendPacket(packet);
-            pressed = true;
+		boolean isKeyUsePressed = mc.options.keyUse.isPressed();
+		
+		if (!(mc.crosshairTarget instanceof BlockHitResult)) {
+			return;
 		}
+		
+		switch (getSetting(1).asMode().mode) {
+		
+		case 0:
+			if (((IMixinMinecraftClient) mc).getItemUseCooldown() == 4 && isKeyUsePressed) {
+				sendInteractionBlockC2SPacket();
+			}
+			break;
 			
-		else if (!mc.options.keyUse.isPressed()) {
-			pressed = false;
+		case 1:
+			if (!pressed && isKeyUsePressed) {
+				sendInteractionBlockC2SPacket();
+	            pressed = true;
+			} else if (!isKeyUsePressed) {
+				pressed = false;
+			}
+			break;
 		}
 	}
 	
 	@Subscribe
 	public void onWorldRender (EventWorldRender event) {
-		if (mc.crosshairTarget instanceof BlockHitResult && getSetting(0).asToggle().state) {
-			BlockPos pos = new BlockPos(mc.crosshairTarget.getPos());
-			int mode = getSetting(0).asToggle().getChild(0).asMode().mode;
-			if (mode == 0 || mode == 2) {
-				float fillAlpha = (float) getSetting(0).asToggle().getChild(2).asSlider().getValue();
-				float[] rgb = getSetting(0).asToggle().getChild(3).asColor().getRGBFloat();
-				RenderUtils.drawFill(pos, rgb[0], rgb[1], rgb[2], fillAlpha);
-			}
-			
-			if (mode == 0 || mode == 1) {
-				float outlineWidth = (float) getSetting(0).asToggle().getChild(1).asSlider().getValue();
-				float[] rgb = getSetting(0).asToggle().getChild(3).asColor().getRGBFloat();
-				RenderUtils.drawOutline(pos, rgb[0], rgb[1], rgb[2], 1f, outlineWidth);
+		if (!(mc.crosshairTarget instanceof BlockHitResult) || !getSetting(0).asToggle().state) {
+			return;
+		}
+		
+		BlockPos pos = new BlockPos(mc.crosshairTarget.getPos());
+		BlockState state = mc.world.getBlockState(pos);
+		VoxelShape voxelShape = state.getOutlineShape(mc.world, pos);
+		if (voxelShape.isEmpty()) {
+			voxelShape = VoxelShapes.cuboid(0, 0, 0, 1, 1, 1);
+		}
+		
+		int mode = getSetting(0).asToggle().getChild(0).asMode().mode;
+		float[] rgb = getSetting(0).asToggle().getChild(3).asColor().getRGBFloat();
+		
+		if (mode == 0 || mode == 1) {
+			float outlineWidth = (float) getSetting(0).asToggle().getChild(1).asSlider().getValue();
+			for (Box box: voxelShape.getBoundingBoxes()) {
+				RenderUtils.drawOutline(box.offset(pos), rgb[0], rgb[1], rgb[2], 1f, outlineWidth);
 			}
 		}
-	}	
+		if (mode == 0 || mode == 2) {
+			float fillAlpha = (float) getSetting(0).asToggle().getChild(2).asSlider().getValue();
+			for (Box box: voxelShape.getBoundingBoxes()) {
+				RenderUtils.drawFill(box.offset(pos), rgb[0], rgb[1], rgb[2], fillAlpha);
+			}
+		}
+	}
+	
 	
 	@Subscribe
-	public void onSendPacket(EventSendPacket event) {
-		if (event.getPacket() instanceof PlayerInteractBlockC2SPacket)
+	public void onSendPacket (EventSendPacket event) {
+		if (event.getPacket() instanceof PlayerInteractBlockC2SPacket) {
 			event.setCancelled(true);
+		}
+	}
+	
+	private void sendInteractionBlockC2SPacket() {
+		PlayerInteractBlockC2SPacket packet = new PlayerInteractBlockC2SPacket(Hand.MAIN_HAND, (BlockHitResult) mc.crosshairTarget);
+		mc.getNetworkHandler().sendPacket(packet);
 	}
 }

--- a/BleachHack-Fabric-1.16/src/main/java/bleach/hack/module/mods/PlaceInAir.java
+++ b/BleachHack-Fabric-1.16/src/main/java/bleach/hack/module/mods/PlaceInAir.java
@@ -1,0 +1,71 @@
+package bleach.hack.module.mods;
+
+import com.google.common.eventbus.Subscribe;
+
+import bleach.hack.event.events.EventSendPacket;
+import bleach.hack.event.events.EventTick;
+import bleach.hack.event.events.EventWorldRender;
+import bleach.hack.module.Category;
+import bleach.hack.module.Module;
+import bleach.hack.setting.base.SettingColor;
+import bleach.hack.setting.base.SettingMode;
+import bleach.hack.setting.base.SettingSlider;
+import bleach.hack.setting.base.SettingToggle;
+import bleach.hack.util.RenderUtils;
+import net.minecraft.network.packet.c2s.play.PlayerInteractBlockC2SPacket;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
+
+public class PlaceInAir extends Module {
+	private boolean pressed;
+	public static boolean shouldSendPacket;
+	
+	public PlaceInAir () {
+		super("PlaceInAir", KEY_UNBOUND, Category.WORLD, "Allows you to place blocks and entities in thin air",
+				new SettingToggle("Rendered", true).withDesc("Renders an overlay where it will place the block / entity").withChildren(
+					new SettingMode("Render", "Box+Fill", "Box", "Fill").withDesc("The rendering method"),
+					new SettingSlider("Box", 0.1, 4, 2, 1).withDesc("The thickness of the box lines"),
+					new SettingSlider("Fill", 0, 1, 0.3, 2).withDesc("The opacity of the fill"),
+					new SettingColor("Color", 1f, 1f, 0f, false)));
+	}
+	
+	@Subscribe
+	public void onTick (EventTick event) {
+		if (mc.options.keyUse.isPressed() && !pressed && mc.crosshairTarget instanceof BlockHitResult) {
+			shouldSendPacket = false;
+            PlayerInteractBlockC2SPacket packet = new PlayerInteractBlockC2SPacket(Hand.MAIN_HAND, (BlockHitResult) mc.crosshairTarget);
+            mc.getNetworkHandler().sendPacket(packet);
+            pressed = true;
+		}
+			
+		else if (!mc.options.keyUse.isPressed()) {
+			pressed = false;
+		}
+	}
+	
+	@Subscribe
+	public void onWorldRender (EventWorldRender event) {
+		if (mc.crosshairTarget instanceof BlockHitResult && getSetting(0).asToggle().state) {
+			BlockPos pos = new BlockPos(mc.crosshairTarget.getPos());
+			int mode = getSetting(0).asToggle().getChild(0).asMode().mode;
+			if (mode == 0 || mode == 2) {
+				float fillAlpha = (float) getSetting(0).asToggle().getChild(2).asSlider().getValue();
+				float[] rgb = getSetting(0).asToggle().getChild(3).asColor().getRGBFloat();
+				RenderUtils.drawFill(pos, rgb[0], rgb[1], rgb[2], fillAlpha);
+			}
+			
+			if (mode == 0 || mode == 1) {
+				float outlineWidth = (float) getSetting(0).asToggle().getChild(1).asSlider().getValue();
+				float[] rgb = getSetting(0).asToggle().getChild(3).asColor().getRGBFloat();
+				RenderUtils.drawOutline(pos, rgb[0], rgb[1], rgb[2], 1f, outlineWidth);
+			}
+		}
+	}	
+	
+	@Subscribe
+	public void onSendPacket(EventSendPacket event) {
+		if (event.getPacket() instanceof PlayerInteractBlockC2SPacket)
+			event.setCancelled(true);
+	}
+}

--- a/BleachHack-Fabric-1.16/src/main/java/bleach/hack/module/mods/PlaceInAir.java
+++ b/BleachHack-Fabric-1.16/src/main/java/bleach/hack/module/mods/PlaceInAir.java
@@ -13,14 +13,12 @@ import bleach.hack.setting.base.SettingMode;
 import bleach.hack.setting.base.SettingSlider;
 import bleach.hack.setting.base.SettingToggle;
 import bleach.hack.util.RenderUtils;
-import net.minecraft.block.BlockState;
+import net.minecraft.block.AirBlock;
+import net.minecraft.block.Block;
 import net.minecraft.network.packet.c2s.play.PlayerInteractBlockC2SPacket;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Box;
-import net.minecraft.util.shape.VoxelShape;
-import net.minecraft.util.shape.VoxelShapes;
 
 /**
  * @author <a href="https://github.com/lasnikprogram">Lasnik</a>
@@ -73,26 +71,22 @@ public class PlaceInAir extends Module {
 		}
 		
 		BlockPos pos = new BlockPos(mc.crosshairTarget.getPos());
-		BlockState state = mc.world.getBlockState(pos);
-		VoxelShape voxelShape = state.getOutlineShape(mc.world, pos);
-		if (voxelShape.isEmpty()) {
-			voxelShape = VoxelShapes.cuboid(0, 0, 0, 1, 1, 1);
+		Block block = mc.world.getBlockState(pos).getBlock();
+		if (!(block instanceof AirBlock)) {
+			return;
 		}
 		
 		int mode = getSetting(0).asToggle().getChild(0).asMode().mode;
 		float[] rgb = getSetting(0).asToggle().getChild(3).asColor().getRGBFloat();
 		
-		if (mode == 0 || mode == 1) {
-			float outlineWidth = (float) getSetting(0).asToggle().getChild(1).asSlider().getValue();
-			for (Box box: voxelShape.getBoundingBoxes()) {
-				RenderUtils.drawOutline(box.offset(pos), rgb[0], rgb[1], rgb[2], 1f, outlineWidth);
-			}
-		}
 		if (mode == 0 || mode == 2) {
 			float fillAlpha = (float) getSetting(0).asToggle().getChild(2).asSlider().getValue();
-			for (Box box: voxelShape.getBoundingBoxes()) {
-				RenderUtils.drawFill(box.offset(pos), rgb[0], rgb[1], rgb[2], fillAlpha);
-			}
+			RenderUtils.drawFill(pos, rgb[0], rgb[1], rgb[2], fillAlpha);
+		}
+
+		if (mode == 0 || mode == 1) {
+			float outlineWidth = (float) getSetting(0).asToggle().getChild(1).asSlider().getValue();
+			RenderUtils.drawOutline(pos, rgb[0], rgb[1], rgb[2], 1f, outlineWidth);
 		}
 	}
 	

--- a/BleachHack-Fabric-1.16/src/main/java/bleach/hack/module/mods/PlaceInAir.java
+++ b/BleachHack-Fabric-1.16/src/main/java/bleach/hack/module/mods/PlaceInAir.java
@@ -53,7 +53,7 @@ public class PlaceInAir extends Module {
 			}
 			break;
 			
-		case 1:
+		default:
 			if (!pressed && isKeyUsePressed) {
 				sendInteractionBlockC2SPacket();
 	            pressed = true;
@@ -79,15 +79,16 @@ public class PlaceInAir extends Module {
 		int mode = getSetting(0).asToggle().getChild(0).asMode().mode;
 		float[] rgb = getSetting(0).asToggle().getChild(3).asColor().getRGBFloat();
 		
+		if (mode == 0 || mode == 1) {
+			float outlineWidth = (float) getSetting(0).asToggle().getChild(1).asSlider().getValue();
+			RenderUtils.drawOutline(pos, rgb[0], rgb[1], rgb[2], 1f, outlineWidth);
+		}
+		
 		if (mode == 0 || mode == 2) {
 			float fillAlpha = (float) getSetting(0).asToggle().getChild(2).asSlider().getValue();
 			RenderUtils.drawFill(pos, rgb[0], rgb[1], rgb[2], fillAlpha);
 		}
 
-		if (mode == 0 || mode == 1) {
-			float outlineWidth = (float) getSetting(0).asToggle().getChild(1).asSlider().getValue();
-			RenderUtils.drawOutline(pos, rgb[0], rgb[1], rgb[2], 1f, outlineWidth);
-		}
 	}
 	
 	

--- a/BleachHack-Fabric-1.16/src/main/resources/bleachhack.mixins.json
+++ b/BleachHack-Fabric-1.16/src/main/resources/bleachhack.mixins.json
@@ -6,6 +6,7 @@
   ],
   "client": [
     "IMixinHeldItemRenderer",
+    "IMixinMinecraftClient",
     "MixinBackgroundRenderer",
   	"MixinAbstractBlock",
   	"MixinBeaconScreen",

--- a/BleachHack-Fabric-1.16/src/main/resources/bleachhack.modules.json
+++ b/BleachHack-Fabric-1.16/src/main/resources/bleachhack.modules.json
@@ -59,6 +59,7 @@
     "OffhandCrash",
     "PacketFly",
     "Peek",
+    "PlaceInAir",
     "PlayerCrash",
     "RotationSnap",
     "SafeWalk",

--- a/BleachHack-Fabric-1.17/src/main/java/bleach/hack/mixin/IMixinMinecraftClient.java
+++ b/BleachHack-Fabric-1.17/src/main/java/bleach/hack/mixin/IMixinMinecraftClient.java
@@ -1,0 +1,12 @@
+package bleach.hack.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.client.MinecraftClient;
+
+@Mixin(MinecraftClient.class)
+public interface IMixinMinecraftClient {
+	@Accessor
+	public abstract int getItemUseCooldown();
+}

--- a/BleachHack-Fabric-1.17/src/main/java/bleach/hack/module/mods/PlaceInAir.java
+++ b/BleachHack-Fabric-1.17/src/main/java/bleach/hack/module/mods/PlaceInAir.java
@@ -5,6 +5,7 @@ import com.google.common.eventbus.Subscribe;
 import bleach.hack.event.events.EventSendPacket;
 import bleach.hack.event.events.EventTick;
 import bleach.hack.event.events.EventWorldRender;
+import bleach.hack.mixin.IMixinMinecraftClient;
 import bleach.hack.module.Category;
 import bleach.hack.module.Module;
 import bleach.hack.setting.base.SettingColor;
@@ -12,60 +13,99 @@ import bleach.hack.setting.base.SettingMode;
 import bleach.hack.setting.base.SettingSlider;
 import bleach.hack.setting.base.SettingToggle;
 import bleach.hack.util.RenderUtils;
+import net.minecraft.block.BlockState;
 import net.minecraft.network.packet.c2s.play.PlayerInteractBlockC2SPacket;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.util.shape.VoxelShapes;
+
+/**
+ * @author <a href="https://github.com/lasnikprogram">Lasnik</a>
+ */
 
 public class PlaceInAir extends Module {
 	private boolean pressed;
-	public static boolean shouldSendPacket;
 	
 	public PlaceInAir () {
-		super("PlaceInAir", KEY_UNBOUND, Category.WORLD, "Allows you to place blocks and entities in thin air",
-				new SettingToggle("Rendered", true).withDesc("Renders an overlay where it will place the block / entity").withChildren(
+		super("PlaceInAir", KEY_UNBOUND, Category.WORLD, "Allows you to place blocks in thin air",
+				new SettingToggle("Rendered", true).withDesc("Renders an overlay where it will place the block").withChildren(
 					new SettingMode("Render", "Box+Fill", "Box", "Fill").withDesc("The rendering method"),
 					new SettingSlider("Box", 0.1, 4, 2, 1).withDesc("The thickness of the box lines"),
 					new SettingSlider("Fill", 0, 1, 0.3, 2).withDesc("The opacity of the fill"),
-					new SettingColor("Color", 1f, 1f, 0f, false)));
+					new SettingColor("Color", 240f, 211f, 165f, false)),
+				new SettingMode("Mode", "Multi", "Single").withDesc("Whether to place a block once per click or multiple blocks if the button is held down"));
 	}
 	
 	@Subscribe
 	public void onTick (EventTick event) {
-		if (mc.options.keyUse.isPressed() && !pressed && mc.crosshairTarget instanceof BlockHitResult) {
-			shouldSendPacket = false;
-            PlayerInteractBlockC2SPacket packet = new PlayerInteractBlockC2SPacket(Hand.MAIN_HAND, (BlockHitResult) mc.crosshairTarget);
-            mc.getNetworkHandler().sendPacket(packet);
-            pressed = true;
+		boolean isKeyUsePressed = mc.options.keyUse.isPressed();
+		
+		if (!(mc.crosshairTarget instanceof BlockHitResult)) {
+			return;
 		}
+		
+		switch (getSetting(1).asMode().mode) {
+		
+		case 0:
+			if (((IMixinMinecraftClient) mc).getItemUseCooldown() == 4 && isKeyUsePressed) {
+				sendInteractionBlockC2SPacket();
+			}
+			break;
 			
-		else if (!mc.options.keyUse.isPressed()) {
-			pressed = false;
+		case 1:
+			if (!pressed && isKeyUsePressed) {
+				sendInteractionBlockC2SPacket();
+	            pressed = true;
+			} else if (!isKeyUsePressed) {
+				pressed = false;
+			}
+			break;
 		}
 	}
 	
 	@Subscribe
 	public void onWorldRender (EventWorldRender event) {
-		if (mc.crosshairTarget instanceof BlockHitResult && getSetting(0).asToggle().state) {
-			BlockPos pos = new BlockPos(mc.crosshairTarget.getPos());
-			int mode = getSetting(0).asToggle().getChild(0).asMode().mode;
-			if (mode == 0 || mode == 2) {
-				float fillAlpha = (float) getSetting(0).asToggle().getChild(2).asSlider().getValue();
-				float[] rgb = getSetting(0).asToggle().getChild(3).asColor().getRGBFloat();
-				RenderUtils.drawFill(pos, rgb[0], rgb[1], rgb[2], fillAlpha);
-			}
-			
-			if (mode == 0 || mode == 1) {
-				float outlineWidth = (float) getSetting(0).asToggle().getChild(1).asSlider().getValue();
-				float[] rgb = getSetting(0).asToggle().getChild(3).asColor().getRGBFloat();
-				RenderUtils.drawOutline(pos, rgb[0], rgb[1], rgb[2], 1f, outlineWidth);
+		if (!(mc.crosshairTarget instanceof BlockHitResult) || !getSetting(0).asToggle().state) {
+			return;
+		}
+		
+		BlockPos pos = new BlockPos(mc.crosshairTarget.getPos());
+		BlockState state = mc.world.getBlockState(pos);
+		VoxelShape voxelShape = state.getOutlineShape(mc.world, pos);
+		if (voxelShape.isEmpty()) {
+			voxelShape = VoxelShapes.cuboid(0, 0, 0, 1, 1, 1);
+		}
+		
+		int mode = getSetting(0).asToggle().getChild(0).asMode().mode;
+		float[] rgb = getSetting(0).asToggle().getChild(3).asColor().getRGBFloat();
+		
+		if (mode == 0 || mode == 1) {
+			float outlineWidth = (float) getSetting(0).asToggle().getChild(1).asSlider().getValue();
+			for (Box box: voxelShape.getBoundingBoxes()) {
+				RenderUtils.drawOutline(box.offset(pos), rgb[0], rgb[1], rgb[2], 1f, outlineWidth);
 			}
 		}
-	}	
+		if (mode == 0 || mode == 2) {
+			float fillAlpha = (float) getSetting(0).asToggle().getChild(2).asSlider().getValue();
+			for (Box box: voxelShape.getBoundingBoxes()) {
+				RenderUtils.drawFill(box.offset(pos), rgb[0], rgb[1], rgb[2], fillAlpha);
+			}
+		}
+	}
+	
 	
 	@Subscribe
-	public void onSendPacket(EventSendPacket event) {
-		if (event.getPacket() instanceof PlayerInteractBlockC2SPacket)
+	public void onSendPacket (EventSendPacket event) {
+		if (event.getPacket() instanceof PlayerInteractBlockC2SPacket) {
 			event.setCancelled(true);
+		}
+	}
+	
+	private void sendInteractionBlockC2SPacket() {
+		PlayerInteractBlockC2SPacket packet = new PlayerInteractBlockC2SPacket(Hand.MAIN_HAND, (BlockHitResult) mc.crosshairTarget);
+		mc.getNetworkHandler().sendPacket(packet);
 	}
 }

--- a/BleachHack-Fabric-1.17/src/main/java/bleach/hack/module/mods/PlaceInAir.java
+++ b/BleachHack-Fabric-1.17/src/main/java/bleach/hack/module/mods/PlaceInAir.java
@@ -1,0 +1,71 @@
+package bleach.hack.module.mods;
+
+import com.google.common.eventbus.Subscribe;
+
+import bleach.hack.event.events.EventSendPacket;
+import bleach.hack.event.events.EventTick;
+import bleach.hack.event.events.EventWorldRender;
+import bleach.hack.module.Category;
+import bleach.hack.module.Module;
+import bleach.hack.setting.base.SettingColor;
+import bleach.hack.setting.base.SettingMode;
+import bleach.hack.setting.base.SettingSlider;
+import bleach.hack.setting.base.SettingToggle;
+import bleach.hack.util.RenderUtils;
+import net.minecraft.network.packet.c2s.play.PlayerInteractBlockC2SPacket;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
+
+public class PlaceInAir extends Module {
+	private boolean pressed;
+	public static boolean shouldSendPacket;
+	
+	public PlaceInAir () {
+		super("PlaceInAir", KEY_UNBOUND, Category.WORLD, "Allows you to place blocks and entities in thin air",
+				new SettingToggle("Rendered", true).withDesc("Renders an overlay where it will place the block / entity").withChildren(
+					new SettingMode("Render", "Box+Fill", "Box", "Fill").withDesc("The rendering method"),
+					new SettingSlider("Box", 0.1, 4, 2, 1).withDesc("The thickness of the box lines"),
+					new SettingSlider("Fill", 0, 1, 0.3, 2).withDesc("The opacity of the fill"),
+					new SettingColor("Color", 1f, 1f, 0f, false)));
+	}
+	
+	@Subscribe
+	public void onTick (EventTick event) {
+		if (mc.options.keyUse.isPressed() && !pressed && mc.crosshairTarget instanceof BlockHitResult) {
+			shouldSendPacket = false;
+            PlayerInteractBlockC2SPacket packet = new PlayerInteractBlockC2SPacket(Hand.MAIN_HAND, (BlockHitResult) mc.crosshairTarget);
+            mc.getNetworkHandler().sendPacket(packet);
+            pressed = true;
+		}
+			
+		else if (!mc.options.keyUse.isPressed()) {
+			pressed = false;
+		}
+	}
+	
+	@Subscribe
+	public void onWorldRender (EventWorldRender event) {
+		if (mc.crosshairTarget instanceof BlockHitResult && getSetting(0).asToggle().state) {
+			BlockPos pos = new BlockPos(mc.crosshairTarget.getPos());
+			int mode = getSetting(0).asToggle().getChild(0).asMode().mode;
+			if (mode == 0 || mode == 2) {
+				float fillAlpha = (float) getSetting(0).asToggle().getChild(2).asSlider().getValue();
+				float[] rgb = getSetting(0).asToggle().getChild(3).asColor().getRGBFloat();
+				RenderUtils.drawFill(pos, rgb[0], rgb[1], rgb[2], fillAlpha);
+			}
+			
+			if (mode == 0 || mode == 1) {
+				float outlineWidth = (float) getSetting(0).asToggle().getChild(1).asSlider().getValue();
+				float[] rgb = getSetting(0).asToggle().getChild(3).asColor().getRGBFloat();
+				RenderUtils.drawOutline(pos, rgb[0], rgb[1], rgb[2], 1f, outlineWidth);
+			}
+		}
+	}	
+	
+	@Subscribe
+	public void onSendPacket(EventSendPacket event) {
+		if (event.getPacket() instanceof PlayerInteractBlockC2SPacket)
+			event.setCancelled(true);
+	}
+}

--- a/BleachHack-Fabric-1.17/src/main/java/bleach/hack/module/mods/PlaceInAir.java
+++ b/BleachHack-Fabric-1.17/src/main/java/bleach/hack/module/mods/PlaceInAir.java
@@ -13,14 +13,12 @@ import bleach.hack.setting.base.SettingMode;
 import bleach.hack.setting.base.SettingSlider;
 import bleach.hack.setting.base.SettingToggle;
 import bleach.hack.util.RenderUtils;
-import net.minecraft.block.BlockState;
+import net.minecraft.block.AirBlock;
+import net.minecraft.block.Block;
 import net.minecraft.network.packet.c2s.play.PlayerInteractBlockC2SPacket;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.Box;
-import net.minecraft.util.shape.VoxelShape;
-import net.minecraft.util.shape.VoxelShapes;
 
 /**
  * @author <a href="https://github.com/lasnikprogram">Lasnik</a>
@@ -73,26 +71,22 @@ public class PlaceInAir extends Module {
 		}
 		
 		BlockPos pos = new BlockPos(mc.crosshairTarget.getPos());
-		BlockState state = mc.world.getBlockState(pos);
-		VoxelShape voxelShape = state.getOutlineShape(mc.world, pos);
-		if (voxelShape.isEmpty()) {
-			voxelShape = VoxelShapes.cuboid(0, 0, 0, 1, 1, 1);
+		Block block = mc.world.getBlockState(pos).getBlock();
+		if (!(block instanceof AirBlock)) {
+			return;
 		}
 		
 		int mode = getSetting(0).asToggle().getChild(0).asMode().mode;
 		float[] rgb = getSetting(0).asToggle().getChild(3).asColor().getRGBFloat();
 		
-		if (mode == 0 || mode == 1) {
-			float outlineWidth = (float) getSetting(0).asToggle().getChild(1).asSlider().getValue();
-			for (Box box: voxelShape.getBoundingBoxes()) {
-				RenderUtils.drawOutline(box.offset(pos), rgb[0], rgb[1], rgb[2], 1f, outlineWidth);
-			}
-		}
 		if (mode == 0 || mode == 2) {
 			float fillAlpha = (float) getSetting(0).asToggle().getChild(2).asSlider().getValue();
-			for (Box box: voxelShape.getBoundingBoxes()) {
-				RenderUtils.drawFill(box.offset(pos), rgb[0], rgb[1], rgb[2], fillAlpha);
-			}
+			RenderUtils.drawFill(pos, rgb[0], rgb[1], rgb[2], fillAlpha);
+		}
+
+		if (mode == 0 || mode == 1) {
+			float outlineWidth = (float) getSetting(0).asToggle().getChild(1).asSlider().getValue();
+			RenderUtils.drawOutline(pos, rgb[0], rgb[1], rgb[2], 1f, outlineWidth);
 		}
 	}
 	

--- a/BleachHack-Fabric-1.17/src/main/java/bleach/hack/module/mods/PlaceInAir.java
+++ b/BleachHack-Fabric-1.17/src/main/java/bleach/hack/module/mods/PlaceInAir.java
@@ -53,7 +53,7 @@ public class PlaceInAir extends Module {
 			}
 			break;
 			
-		case 1:
+		default:
 			if (!pressed && isKeyUsePressed) {
 				sendInteractionBlockC2SPacket();
 	            pressed = true;
@@ -79,15 +79,16 @@ public class PlaceInAir extends Module {
 		int mode = getSetting(0).asToggle().getChild(0).asMode().mode;
 		float[] rgb = getSetting(0).asToggle().getChild(3).asColor().getRGBFloat();
 		
+		if (mode == 0 || mode == 1) {
+			float outlineWidth = (float) getSetting(0).asToggle().getChild(1).asSlider().getValue();
+			RenderUtils.drawOutline(pos, rgb[0], rgb[1], rgb[2], 1f, outlineWidth);
+		}
+		
 		if (mode == 0 || mode == 2) {
 			float fillAlpha = (float) getSetting(0).asToggle().getChild(2).asSlider().getValue();
 			RenderUtils.drawFill(pos, rgb[0], rgb[1], rgb[2], fillAlpha);
 		}
 
-		if (mode == 0 || mode == 1) {
-			float outlineWidth = (float) getSetting(0).asToggle().getChild(1).asSlider().getValue();
-			RenderUtils.drawOutline(pos, rgb[0], rgb[1], rgb[2], 1f, outlineWidth);
-		}
 	}
 	
 	

--- a/BleachHack-Fabric-1.17/src/main/resources/bleachhack.mixins.json
+++ b/BleachHack-Fabric-1.17/src/main/resources/bleachhack.mixins.json
@@ -6,6 +6,7 @@
   ],
   "client": [
     "IMixinHeldItemRenderer",
+    "IMixinMinecraftClient",
     "MixinBackgroundRenderer",
   	"MixinAbstractBlock",
   	"MixinBeaconScreen",

--- a/BleachHack-Fabric-1.17/src/main/resources/bleachhack.modules.json
+++ b/BleachHack-Fabric-1.17/src/main/resources/bleachhack.modules.json
@@ -59,6 +59,7 @@
     "OffhandCrash",
     "PacketFly",
     "Peek",
+    "PlaceInAir",
     "PlayerCrash",
     "RotationSnap",
     "SafeWalk",


### PR DESCRIPTION
Allows you to place blocks in thin air. It draws an overlay where the place should get placed:
![grafik](https://user-images.githubusercontent.com/61758940/114735077-2096f380-9d45-11eb-9228-ad45ed657b6e.png)
Has two modes: single and multi.

The only thing I could think of to improve this hack would be to add a (propably live) range setting. But I can´t really think of an user friendly way to do this. If I find one. I´ll add it.