### PR TITLE
Fixed notebot visual bug and added steps for IntelliJ in README

### DIFF
--- a/BleachHack-Fabric-1.17/src/main/java/bleach/hack/gui/NotebotScreen.java
+++ b/BleachHack-Fabric-1.17/src/main/java/bleach/hack/gui/NotebotScreen.java
@@ -142,37 +142,37 @@ public class NotebotScreen extends WindowScreen {
 
 					DiffuseLighting.enableGuiDepthLighting();
 					if (e.getKey() == Instrument.HARP)
-						itemRenderer.renderGuiItemIcon(new ItemStack(Items.DIRT), x + w - w / 4 + 40, y + 46 + c2 * 10);
+						itemRenderer.renderGuiItemIcon(new ItemStack(Items.DIRT), x + w - w / 4 + 55, y + 46 + c2 * 10);
 					else if (e.getKey() == Instrument.BASEDRUM)
-						itemRenderer.renderGuiItemIcon(new ItemStack(Items.STONE), x + w - w / 4 + 40, y + 46 + c2 * 10);
+						itemRenderer.renderGuiItemIcon(new ItemStack(Items.STONE), x + w - w / 4 + 55, y + 46 + c2 * 10);
 					else if (e.getKey() == Instrument.SNARE)
-						itemRenderer.renderGuiItemIcon(new ItemStack(Items.SAND), x + w - w / 4 + 40, y + 46 + c2 * 10);
+						itemRenderer.renderGuiItemIcon(new ItemStack(Items.SAND), x + w - w / 4 + 55, y + 46 + c2 * 10);
 					else if (e.getKey() == Instrument.HAT)
-						itemRenderer.renderGuiItemIcon(new ItemStack(Items.GLASS), x + w - w / 4 + 40, y + 46 + c2 * 10);
+						itemRenderer.renderGuiItemIcon(new ItemStack(Items.GLASS), x + w - w / 4 + 55, y + 46 + c2 * 10);
 					else if (e.getKey() == Instrument.BASS)
-						itemRenderer.renderGuiItemIcon(new ItemStack(Items.OAK_WOOD), x + w - w / 4 + 40, y + 46 + c2 * 10);
+						itemRenderer.renderGuiItemIcon(new ItemStack(Items.OAK_WOOD), x + w - w / 4 + 55, y + 46 + c2 * 10);
 					else if (e.getKey() == Instrument.FLUTE)
-						itemRenderer.renderGuiItemIcon(new ItemStack(Items.CLAY), x + w - w / 4 + 40, y + 46 + c2 * 10);
+						itemRenderer.renderGuiItemIcon(new ItemStack(Items.CLAY), x + w - w / 4 + 55, y + 46 + c2 * 10);
 					else if (e.getKey() == Instrument.BELL)
-						itemRenderer.renderGuiItemIcon(new ItemStack(Items.GOLD_BLOCK), x + w - w / 4 + 40, y + 46 + c2 * 10);
+						itemRenderer.renderGuiItemIcon(new ItemStack(Items.GOLD_BLOCK), x + w - w / 4 + 55, y + 46 + c2 * 10);
 					else if (e.getKey() == Instrument.GUITAR)
-						itemRenderer.renderGuiItemIcon(new ItemStack(Items.WHITE_WOOL), x + w - w / 4 + 40, y + 46 + c2 * 10);
+						itemRenderer.renderGuiItemIcon(new ItemStack(Items.WHITE_WOOL), x + w - w / 4 + 55, y + 46 + c2 * 10);
 					else if (e.getKey() == Instrument.CHIME)
-						itemRenderer.renderGuiItemIcon(new ItemStack(Items.PACKED_ICE), x + w - w / 4 + 40, y + 46 + c2 * 10);
+						itemRenderer.renderGuiItemIcon(new ItemStack(Items.PACKED_ICE), x + w - w / 4 + 55, y + 46 + c2 * 10);
 					else if (e.getKey() == Instrument.XYLOPHONE)
-						itemRenderer.renderGuiItemIcon(new ItemStack(Items.BONE_BLOCK), x + w - w / 4 + 40, y + 46 + c2 * 10);
+						itemRenderer.renderGuiItemIcon(new ItemStack(Items.BONE_BLOCK), x + w - w / 4 + 55, y + 46 + c2 * 10);
 					else if (e.getKey() == Instrument.IRON_XYLOPHONE)
-						itemRenderer.renderGuiItemIcon(new ItemStack(Items.IRON_BLOCK), x + w - w / 4 + 40, y + 46 + c2 * 10);
+						itemRenderer.renderGuiItemIcon(new ItemStack(Items.IRON_BLOCK), x + w - w / 4 + 55, y + 46 + c2 * 10);
 					else if (e.getKey() == Instrument.COW_BELL)
-						itemRenderer.renderGuiItemIcon(new ItemStack(Items.SOUL_SAND), x + w - w / 4 + 40, y + 46 + c2 * 10);
+						itemRenderer.renderGuiItemIcon(new ItemStack(Items.SOUL_SAND), x + w - w / 4 + 55, y + 46 + c2 * 10);
 					else if (e.getKey() == Instrument.DIDGERIDOO)
-						itemRenderer.renderGuiItemIcon(new ItemStack(Items.PUMPKIN), x + w - w / 4 + 40, y + 46 + c2 * 10);
+						itemRenderer.renderGuiItemIcon(new ItemStack(Items.PUMPKIN), x + w - w / 4 + 55, y + 46 + c2 * 10);
 					else if (e.getKey() == Instrument.BIT)
-						itemRenderer.renderGuiItemIcon(new ItemStack(Items.EMERALD_BLOCK), x + w - w / 4 + 40, y + 46 + c2 * 10);
+						itemRenderer.renderGuiItemIcon(new ItemStack(Items.EMERALD_BLOCK), x + w - w / 4 + 55, y + 46 + c2 * 10);
 					else if (e.getKey() == Instrument.BANJO)
-						itemRenderer.renderGuiItemIcon(new ItemStack(Items.HAY_BLOCK), x + w - w / 4 + 40, y + 46 + c2 * 10);
+						itemRenderer.renderGuiItemIcon(new ItemStack(Items.HAY_BLOCK), x + w - w / 4 + 55, y + 46 + c2 * 10);
 					else if (e.getKey() == Instrument.PLING)
-						itemRenderer.renderGuiItemIcon(new ItemStack(Items.GLOWSTONE), x + w - w / 4 + 40, y + 46 + c2 * 10);
+						itemRenderer.renderGuiItemIcon(new ItemStack(Items.GLOWSTONE), x + w - w / 4 + 55, y + 46 + c2 * 10)
 					c2++;
 
 					DiffuseLighting.disableGuiDepthLighting();

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ Generate the needed files for your preferred IDE.
   Start a new workspace in eclipse.
   Click File > Import... > Gradle > Gradle Project.
   Select the BleachHack-Fabric-(*Version*) folder.
+  
+***IntelliJ***
+
+  On Windows:
+  > gradlew genIdeaWorkspace
+  
+  On Linux:
+  > chmod +x ./gradlew  
+  >./gradlew genIdeaWorkspace
+
+  Open build.gradle with Idea and click Open as Project.
 
 ***Other IDE's***
 

--- a/README.md
+++ b/README.md
@@ -66,12 +66,14 @@ Generate the needed files for your preferred IDE.
   > chmod +x ./gradlew  
   >./gradlew genIdeaWorkspace
 
-  Open build.gradle with Idea and click Open as Project.
+  In idea click File > Open.
+  Select build.gradle in BleachHack-Fabric-(*Version*) folder.
+  Select Open as Project.
 
 ***Other IDE's***
 
   Use [this link](https://fabricmc.net/wiki/tutorial:setup) for more information.
-  It should be pretty similar to the eclipse setup.
+  It should be pretty similar to the eclipse and idea setup.
   
 ###### *Note: Java 16 is required for 1.17+*
 


### PR DESCRIPTION
When you have a song in notebot that uses Iron Xylophone, the name Iron_Xylophone goes all the way into the blocks. So I moved the blocks a bit

I also added steps to open IntelliJ